### PR TITLE
filter logs by minimum log level or regex

### DIFF
--- a/log.go
+++ b/log.go
@@ -5,7 +5,6 @@
 // This code may be copied and pasted into your microservice
 // and modified to your liking. Put it in a package called
 // log. A little copying is better than a little dependency.
-//
 package log
 
 import (
@@ -13,11 +12,31 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
+	"sync"
 	"time"
 )
 
 // Line allows a log line to be embedded somewhere
 type Line = line
+
+type LevelInt int
+
+type LogConfig struct {
+	MinLevel         LevelInt
+	RegexPassthrough []string
+	RegexEnabled     bool
+	DebugOn          bool
+	UpdatedAt        time.Time
+}
+
+const (
+	LevelDebug LevelInt = iota + 1
+	LevelInfo
+	LevelWarn
+	LevelError
+	LevelFatal
+)
 
 var (
 	// Service name (can be set in main or elsewhere)
@@ -34,18 +53,27 @@ var (
 
 	// Default is the level used when calling Printf and Fatalf
 	Default = Info
+
+	Config = LogConfig{
+		MinLevel:         LevelDebug,
+		RegexPassthrough: []string{},
+		RegexEnabled:     false,
+		DebugOn:          false,
+		UpdatedAt:        time.Time{},
+	}
+	compiledRegex = []*regexp.Regexp{}
+	setMutex      = sync.Mutex{}
 )
 
 var (
 	// Info, Warn, and so forth are commonly encountered log "levels".
-	Info  = line{Level: "info"}
-	Warn  = line{Level: "warn"}
-	Error = line{Level: "error"}
-	Fatal = line{Level: "fatal"}
+	Info  = line{Level: "info", LevelInt: LevelInfo}
+	Warn  = line{Level: "warn", LevelInt: LevelWarn}
+	Error = line{Level: "error", LevelInt: LevelError}
+	Fatal = line{Level: "fatal", LevelInt: LevelFatal}
 
-	// Debug is a special level, it is only printed if DebugOn is true
-	Debug   = line{Level: "debug"}
-	DebugOn = false
+	// Debug is a special level, it is only printed if Config.DebugOn is true
+	Debug = line{Level: "debug", LevelInt: LevelDebug}
 )
 
 var stderr = io.Writer(os.Stderr)
@@ -65,8 +93,9 @@ func SetOutput(w io.Writer) (old io.Writer) {
 type line struct {
 	fn func(line) line
 	fields
-	Level string
-	msg   string
+	Level    string
+	LevelInt LevelInt
+	msg      string
 }
 
 // Printf attaches the formatted message to line and outputs
@@ -81,8 +110,13 @@ type line struct {
 //
 // Prefer log.Error.F() to log.Error.Printf() unless using Add
 func (l line) Printf(f string, v ...interface{}) {
-	if l.Level == Debug.Level && !DebugOn {
-		return
+	checkDebug := l.Level == Debug.Level && !Config.DebugOn
+	checkMinLevel := l.LevelInt < Config.MinLevel
+	if checkDebug || checkMinLevel {
+		// check to see if message matches any regex to allow message to be printed
+		if !RegexPassthrough(f, v...) {
+			return
+		}
 	}
 	fmt.Fprintln(stderr, l.Msg(f, v...).String())
 	if l.Level == "fatal" {
@@ -224,8 +258,8 @@ type trapme string
 // not affected. Trap calls os.Exit(1) if the panic occured from these
 // functions.
 //
-// func main(){
-// 		defer log.Trap()
+//	func main(){
+//			defer log.Trap()
 //
 // }
 func Trap() {
@@ -244,4 +278,34 @@ func zero(v interface{}) bool {
 		return false
 	}
 	return len(t) == 0
+}
+
+func SetLogConfig(config LogConfig) error {
+	setMutex.Lock()
+	defer setMutex.Unlock()
+	Config = config
+	// compile the regexes
+	for _, exp := range config.RegexPassthrough {
+		reg, err := regexp.Compile(exp)
+		if err != nil {
+			return err
+		}
+		compiledRegex = append(compiledRegex, reg)
+	}
+	return nil
+}
+
+func RegexPassthrough(f string, v ...interface{}) bool {
+	if !Config.RegexEnabled {
+		return false
+	}
+	setMutex.Lock()
+	defer setMutex.Unlock()
+	msg := fmt.Sprintf(f, v...)
+	for _, reg := range compiledRegex {
+		if reg.MatchString(msg) {
+			return true
+		}
+	}
+	return false
 }

--- a/log.go
+++ b/log.go
@@ -110,9 +110,11 @@ type line struct {
 //
 // Prefer log.Error.F() to log.Error.Printf() unless using Add
 func (l line) Printf(f string, v ...interface{}) {
-	checkDebug := l.Level == Debug.Level && !Config.DebugOn
-	checkMinLevel := l.LevelInt < Config.MinLevel
-	if checkDebug || checkMinLevel {
+	// if msg is debug, checks if log msg should NOT be printed
+	exitDebugMsg := l.Level == Debug.Level && !Config.DebugOn
+	// for other levels, checks if log msg should NOT be printed based on min level
+	exitMinLevelMsg := l.LevelInt < Config.MinLevel
+	if exitDebugMsg || exitMinLevelMsg {
 		// check to see if message matches any regex to allow message to be printed
 		if !RegexPassthrough(f, v...) {
 			return

--- a/log_test.go
+++ b/log_test.go
@@ -1,12 +1,14 @@
 package log_test
 
 import (
+	"bytes"
 	"io"
 	"io/ioutil"
 	"os"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	log "github.com/cbsinteractive/mc-log"
 )
@@ -143,6 +145,334 @@ func TestAddArray(t *testing.T) {
 	want := `{"svc":"test", "ts":12345, "level":"error", "ip":"1.2.3.4", "port":"1111", "client":"mothra", "host":"example.com", "path":"/file.txt", "query":"what", "err":"EOF", "msg":"custom fields"}`
 	if have != want {
 		t.Fatalf("bad log:\n\t\thave: %s\n\t\twant: %s", have, want)
+	}
+}
+
+func TestPrintf_LogConfig(t *testing.T) {
+	tests := []struct {
+		name           string
+		setup          func(*testing.T) func() // setup function returns cleanup function
+		line           log.Line
+		format         string
+		args           []interface{}
+		expectedOutput string
+		expectEmpty    bool
+	}{
+		{
+			name: "Debug with DebugOn true",
+			setup: func(*testing.T) func() {
+				oldDebugOn := log.Config.DebugOn
+				log.Config.DebugOn = true
+				return func() { log.Config.DebugOn = oldDebugOn }
+			},
+			line:           log.Debug,
+			format:         "debug message: %s",
+			args:           []interface{}{"enabled"},
+			expectedOutput: `{"svc":"test", "ts":12345, "level":"debug", "msg":"debug message: enabled"}`,
+		},
+		{
+			name: "Debug with DebugOn false",
+			setup: func(*testing.T) func() {
+				oldDebugOn := log.Config.DebugOn
+				log.Config.DebugOn = false
+				return func() { log.Config.DebugOn = oldDebugOn }
+			},
+			line:        log.Debug,
+			format:      "debug message: %s",
+			args:        []interface{}{"disabled"},
+			expectEmpty: true,
+		},
+		{
+			name: "Debug with regex allowlist matching",
+			setup: func(t *testing.T) func() {
+				oldDebugOn := log.Config.DebugOn
+				log.Config.DebugOn = false
+				err := log.SetLogConfig(log.LogConfig{
+					MinLevel:         log.LevelDebug,
+					RegexPassthrough: []string{".*important.*"},
+					RegexEnabled:     true,
+					UpdatedAt:        time.Now(),
+				})
+				if err != nil {
+					t.Fatalf("failed to set regex list: %v", err)
+				}
+				return func() {
+					log.Config.DebugOn = oldDebugOn
+					log.SetLogConfig(log.LogConfig{
+						MinLevel:         log.LevelDebug,
+						RegexPassthrough: []string{},
+						RegexEnabled:     true,
+						UpdatedAt:        time.Time{},
+					})
+				}
+			},
+			line:           log.Debug,
+			format:         "important debug message",
+			args:           nil,
+			expectedOutput: `{"svc":"test", "ts":12345, "level":"debug", "msg":"important debug message"}`,
+		},
+		{
+			name: "Debug with regex allowlist not matching",
+			setup: func(t *testing.T) func() {
+				oldDebugOn := log.Config.DebugOn
+				log.Config.DebugOn = false
+				err := log.SetLogConfig(log.LogConfig{
+					MinLevel:         log.LevelDebug,
+					RegexPassthrough: []string{".*important.*"},
+					RegexEnabled:     true,
+					UpdatedAt:        time.Now(),
+				})
+				if err != nil {
+					t.Fatalf("failed to set regex list: %v", err)
+				}
+				return func() {
+					log.Config.DebugOn = oldDebugOn
+					log.SetLogConfig(log.LogConfig{
+						MinLevel:         log.LevelDebug,
+						RegexPassthrough: []string{},
+						RegexEnabled:     true,
+						UpdatedAt:        time.Time{},
+					})
+				}
+			},
+			line:        log.Debug,
+			format:      "regular debug message",
+			args:        nil,
+			expectEmpty: true,
+		},
+		{
+			name: "Info below MinLogLevel (filtered)",
+			setup: func(t *testing.T) func() {
+				err := log.SetLogConfig(log.LogConfig{
+					MinLevel:         log.LevelWarn,
+					RegexPassthrough: []string{},
+					RegexEnabled:     true,
+					UpdatedAt:        time.Now(),
+				})
+
+				if err != nil {
+					t.Fatalf("failed to set min log level: %v", err)
+				}
+				return func() {
+					log.SetLogConfig(log.LogConfig{
+						MinLevel:         log.LevelDebug,
+						RegexPassthrough: []string{},
+						RegexEnabled:     true,
+						UpdatedAt:        time.Time{},
+					})
+				}
+			},
+			line:        log.Info,
+			format:      "info message",
+			args:        nil,
+			expectEmpty: true,
+		},
+		{
+			name: "Warn at MinLogLevel (printed)",
+			setup: func(t *testing.T) func() {
+				err := log.SetLogConfig(log.LogConfig{
+					MinLevel:         log.LevelWarn,
+					RegexPassthrough: []string{},
+					RegexEnabled:     true,
+					UpdatedAt:        time.Now(),
+				})
+				if err != nil {
+					t.Fatalf("failed to set min log level: %v", err)
+				}
+				return func() {
+					log.SetLogConfig(log.LogConfig{
+						MinLevel:         log.LevelDebug,
+						RegexPassthrough: []string{},
+						RegexEnabled:     true,
+						UpdatedAt:        time.Time{},
+					})
+				}
+			},
+			line:           log.Warn,
+			format:         "warn message",
+			args:           nil,
+			expectedOutput: `{"svc":"test", "ts":12345, "level":"warn", "msg":"warn message"}`,
+		},
+		{
+			name: "Error above MinLogLevel (printed)",
+			setup: func(t *testing.T) func() {
+				err := log.SetLogConfig(log.LogConfig{
+					MinLevel:         log.LevelWarn,
+					RegexPassthrough: []string{},
+					RegexEnabled:     true,
+					UpdatedAt:        time.Now(),
+				})
+				if err != nil {
+					t.Fatalf("failed to set min log level: %v", err)
+				}
+				return func() {
+					log.SetLogConfig(log.LogConfig{
+						MinLevel:         log.LevelDebug,
+						RegexPassthrough: []string{},
+						RegexEnabled:     true,
+						UpdatedAt:        time.Time{},
+					})
+				}
+			},
+			line:           log.Error,
+			format:         "error message",
+			args:           nil,
+			expectedOutput: `{"svc":"test", "ts":12345, "level":"error", "msg":"error message"}`,
+		},
+		{
+			name: "Info below MinLogLevel with regex allowlist matching",
+			setup: func(t *testing.T) func() {
+				err := log.SetLogConfig(log.LogConfig{
+					MinLevel:         log.LevelWarn,
+					RegexPassthrough: []string{".*critical.*"},
+					RegexEnabled:     true,
+					UpdatedAt:        time.Now(),
+				})
+				if err != nil {
+					t.Fatalf("failed to set min log level: %v", err)
+				}
+				return func() {
+					log.SetLogConfig(log.LogConfig{
+						MinLevel:         log.LevelDebug,
+						RegexPassthrough: []string{},
+						RegexEnabled:     true,
+						UpdatedAt:        time.Time{},
+					})
+				}
+			},
+			line:           log.Info,
+			format:         "critical info message",
+			args:           nil,
+			expectedOutput: `{"svc":"test", "ts":12345, "level":"info", "msg":"critical info message"}`,
+		},
+		{
+			name: "Info below MinLogLevel with regex allowlist not matching",
+			setup: func(t *testing.T) func() {
+				err := log.SetLogConfig(log.LogConfig{
+					MinLevel:         log.LevelWarn,
+					RegexPassthrough: []string{".*critical.*"},
+					RegexEnabled:     true,
+					UpdatedAt:        time.Now(),
+				})
+				if err != nil {
+					t.Fatalf("failed to set min log level: %v", err)
+				}
+				return func() {
+					log.SetLogConfig(log.LogConfig{
+						MinLevel:         log.LevelDebug,
+						RegexPassthrough: []string{},
+						RegexEnabled:     true,
+						UpdatedAt:        time.Time{},
+					})
+				}
+			},
+			line:        log.Info,
+			format:      "regular info message",
+			args:        nil,
+			expectEmpty: true,
+		},
+		{
+			name: "Multiple regex patterns - first matches",
+			setup: func(t *testing.T) func() {
+				err := log.SetLogConfig(log.LogConfig{
+					MinLevel:         log.LevelFatal,
+					RegexPassthrough: []string{".*error.*", ".*warning.*"},
+					RegexEnabled:     true,
+					UpdatedAt:        time.Now(),
+				})
+				if err != nil {
+					t.Fatalf("failed to set regex list: %v", err)
+				}
+				return func() {
+					log.SetLogConfig(log.LogConfig{
+						MinLevel:         log.LevelDebug,
+						RegexPassthrough: []string{},
+						RegexEnabled:     true,
+						UpdatedAt:        time.Time{},
+					})
+				}
+			},
+			line:           log.Debug,
+			format:         "debug error message",
+			args:           nil,
+			expectedOutput: `{"svc":"test", "ts":12345, "level":"debug", "msg":"debug error message"}`,
+		},
+		{
+			name: "Multiple regex patterns - second matches",
+			setup: func(t *testing.T) func() {
+				err := log.SetLogConfig(log.LogConfig{
+					MinLevel:         log.LevelFatal,
+					RegexPassthrough: []string{".*error.*", ".*warning.*"},
+					RegexEnabled:     true,
+					UpdatedAt:        time.Now(),
+				})
+				if err != nil {
+					t.Fatalf("failed to set regex list: %v", err)
+				}
+				return func() {
+					log.SetLogConfig(log.LogConfig{
+						MinLevel:         log.LevelDebug,
+						RegexPassthrough: []string{},
+						RegexEnabled:     true,
+						UpdatedAt:        time.Time{},
+					})
+				}
+			},
+			line:           log.Debug,
+			format:         "debug warning message",
+			args:           nil,
+			expectedOutput: `{"svc":"test", "ts":12345, "level":"debug", "msg":"debug warning message"}`,
+		},
+		{
+			name: "Multiple regex patterns - neither matches",
+			setup: func(t *testing.T) func() {
+				err := log.SetLogConfig(log.LogConfig{
+					MinLevel:         log.LevelFatal,
+					RegexPassthrough: []string{".*error.*", ".*warning.*"},
+					RegexEnabled:     true,
+					UpdatedAt:        time.Now(),
+				})
+				if err != nil {
+					t.Fatalf("failed to set regex list: %v", err)
+				}
+				return func() {
+					log.SetLogConfig(log.LogConfig{
+						MinLevel:         log.LevelDebug,
+						RegexPassthrough: []string{},
+						RegexEnabled:     true,
+						UpdatedAt:        time.Time{},
+					})
+				}
+			},
+			line:        log.Debug,
+			format:      "debug regular message",
+			args:        nil,
+			expectEmpty: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			oldOutput := log.SetOutput(&buf)
+			defer log.SetOutput(oldOutput)
+
+			cleanup := tt.setup(t)
+			defer cleanup()
+
+			tt.line.Printf(tt.format, tt.args...)
+
+			output := buf.String()
+			if tt.expectEmpty {
+				if output != "" {
+					t.Fatalf("expected no output, got: %s", output)
+				}
+			} else if tt.expectedOutput != "" {
+				if !strings.Contains(output, tt.expectedOutput) {
+					t.Fatalf("bad log output:\n\t\thave: %s\n\t\twant to contain: %s", output, tt.expectedOutput)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
adds a LogConfig with the following settings:
- minimum log level
- regex passthrough
- a regex enabled flag